### PR TITLE
Reduce memory footprint

### DIFF
--- a/src/map_reads.cpp
+++ b/src/map_reads.cpp
@@ -178,7 +178,7 @@ transposeXU( std::vector< boost::dynamic_bitset<> > &XUT )
         	pos = bitset.find_next(pos);
         }
         // release memory
-        bitset.swap(bitmap_t()); // apparently the swap trick is still the most reliable way to accomplish this // bitset.resize(0); bitset.shrink_to_fit();
+        bitset.resize(0); bitmap_t(bitset).swap(bitset);
 	}
 	return XU;
 }
@@ -340,7 +340,7 @@ void map_reads::execute ()
     // Peak memory use occurs at the start and will be twice the matrix size (= 2 * (nbContigs*strains->size()/8) bytes).
     cout << "[Transpose pattern matrix..]" << endl;
     auto XU = transposeXU( allUnitigPatterns ); // this will consume allUnitigPatterns while transposing
-    allUnitigPatterns.swap(bitmap_container_t()); // release memory
+    allUnitigPatterns.resize(0); bitmap_container_t(allUnitigPatterns).swap(allUnitigPatterns); // release memory
 
     //generate the pyseer input
     cout << "[Generating pyseer input]..." << endl;


### PR DESCRIPTION
Hi John,

Please consider these changes to your repository.

When processing large data sets (as in >a few k strains/samples) the memory consumption of unitig-counter is dominated by the unitig pattern matrix in `map_reads.cpp`, to the point where available memory becomes a limiting factor for actually running the program.

What I've done here is target the low hanging fruit and changed the pattern matrix storage from a `vector< vector<int> >` to a `vector< boost::dynamic_bitset >`, which reduces the required memory by a factor of 32. I've also removed the temporary output of unitig patterns to disk, but in return the pattern matrix needs to be transposed in memory, momentarily doubling matrix memory. The effective reduction in memory footprint is therefore cut in half, so in the end there's only a factor of 16 reduction.

The output order of unitig patterns differ slightly from the original code, due to the different sorting behavior of `boost::dynamic_bitset` compared to `vector<int>`, but the output should still be internally consistent. If not, then this can be fixed.

All the best,
Santeri
