### PR TITLE
Compress output using gzip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ include (GatbCore)
 # find Boost
 set(BOOST_ROOT /usr/bin/include)
 set(Boost_USE_STATIC_LIBS   ON)
-FIND_PACKAGE(Boost 1.69.0 COMPONENTS program_options filesystem system regex REQUIRED)
+FIND_PACKAGE(Boost 1.69.0 COMPONENTS program_options filesystem system regex iostreams REQUIRED)
 include_directories(${Boost_INCLUDE_DIR})
 
 # cdbg-ops target
@@ -102,7 +102,7 @@ set (PROGRAM_SOURCE_DIR ${PROJECT_SOURCE_DIR}/src)
 include_directories (${PROGRAM_SOURCE_DIR})
 file (GLOB_RECURSE  ProjectFiles  ${PROGRAM_SOURCE_DIR}/*.cpp)
 add_executable(${PROGRAM} ${ProjectFiles})
-target_link_libraries(${PROGRAM} ${gatb-core-libraries} ${Boost_LIBRARIES} -static-libgcc -static-libstdc++)
+target_link_libraries(${PROGRAM} ${gatb-core-libraries} ${Boost_LIBRARIES} -lz -static-libgcc -static-libstdc++)
 
 ################################################################################
 #  INSTALLATION

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -36,6 +36,7 @@ const char* STR_STRAINS_FILE = "-strains";
 const char* STR_KSKMER_SIZE = "-k";
 const char* STR_OUTPUT = "-output";
 const char* STR_NBCORES = "-nb-cores";
+const char* STR_GZIP = "-gzip";
 
 //global vars used by both programs
 Graph *graph;
@@ -47,4 +48,5 @@ void populateParser (Tool *tool) {
   tool->getParser()->push_front (new OptionOneParam (STR_OUTPUT, "Path to the folder where the final and temporary files will be stored.",  false, "output"));
   tool->getParser()->push_front (new OptionOneParam (STR_KSKMER_SIZE, "K-mer size.",  false, "31"));
   tool->getParser()->push_front (new OptionOneParam (STR_STRAINS_FILE, "A text file describing the strains containing 2 columns: 1) ID of the strain; 2) Path to a multi-fasta file containing the sequences of the strain. This file needs a header.",  true));
+  tool->getParser()->push_front (new OptionNoParam (STR_GZIP, "Compress unitig output using gzip.", false));
 }

--- a/src/global.h
+++ b/src/global.h
@@ -40,6 +40,7 @@ extern const char* STR_STRAINS_FILE;
 extern const char* STR_KSKMER_SIZE;
 extern const char* STR_OUTPUT;
 extern const char* STR_NBCORES;
+extern const char* STR_GZIP;
 
 void populateParser (Tool *tool);
 


### PR DESCRIPTION
Here's what you could do as a quick fix for reducing the size of `unitigs.txt` and `unitigs.unique_rows.Rtab`, which tend to become excessively large. The suggested code adds a new option `-gzip` that will do exactly that using the gzip filter from `boost::iostreams`. It will unfortunately also add compile-time dependencies to said boost lib as well as to zlib.. but since you already depend on boost, and zlib is available pretty much everywhere, that shouldn't be a huge problem.